### PR TITLE
Fix Error Code Returned by Tool for XML Files With Missing Magento Schema Declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For more information about the extension, please refer to the
 [README](./README.md) document.
 
 ## [Unreleased]
+### Fixed
+- Warnings for missing Magento schema declarations are no longer returned as
+errors
 
 ## [0.2.0] — 2022-11-07
 ### Changed

--- a/src/Console/Command/ValidateXmlCommand.php
+++ b/src/Console/Command/ValidateXmlCommand.php
@@ -222,7 +222,7 @@ class ValidateXmlCommand extends Command
                 ]
             );
 
-            return false;
+            return true;
         }
 
         if (count($errors) > 0) {

--- a/test/Integration/Console/Command/ValidateXmlCommandTest.php
+++ b/test/Integration/Console/Command/ValidateXmlCommandTest.php
@@ -125,6 +125,7 @@ final class ValidateXmlCommandTest extends TestCase
     {
         $paths = [
             'valid_module_xml' => __DIR__ . '/../../_files/valid/module.xml',
+            'valid_config_xml' => __DIR__ . '/../../_files/valid/config.xml',
             'invalid_module_xml' => __DIR__ . '/../../_files/invalid/module.xml',
             'excluded_phpunit_xml' => 'phpunit.xml',
             'excluded_phpunit_xml_full' => __DIR__ . '/../../_files/invalid/phpunit.xml',
@@ -206,6 +207,26 @@ final class ValidateXmlCommandTest extends TestCase
 
                 OUTPUT,
                 'expectedReturnCode' => 1
+            ],
+            'missing Magento schema declaration in config.xml' => [
+                'commandOptions' => [
+                    'paths' => [
+                        $paths['valid_config_xml']
+                    ]
+                ],
+                'expectedOutput' => <<<OUTPUT
+
+                Imagination Media XML Validator
+                ===============================
+
+                 [WARNING] XML file
+                           "{$relativePaths['valid_config_xml']}" does
+                           not have a Magento schema defined
+
+                1 of 1 file is valid
+
+                OUTPUT,
+                'expectedReturnCode' => 0
             ],
             'non-Magento XML file' => [
                 'commandOptions' => [

--- a/test/Integration/_files/valid/config.xml
+++ b/test/Integration/_files/valid/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config>
+    <default>
+        <imaginationmedia_xml_validator>
+            <general>
+                <active>1</active>
+            </general>
+        </imaginationmedia_xml_validator>
+    </default>
+</config>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Relates to TMC-67 <!-- JIRA ticket number -->

## Description
<!--- Describe your changes in detail -->
- Fixes the incorrect error code returned when a given XML file is missing a Magento schema declaration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes GitHub Actions workflow breaking for otherwise valid XML files

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- This been tested with an Integration Test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- Template source: https://www.talater.com/open-source-templates/ -->
