### PR TITLE
Change ValidateXmlCommand constructor name parameter type

### DIFF
--- a/src/Console/Command/ValidateXmlCommand.php
+++ b/src/Console/Command/ValidateXmlCommand.php
@@ -65,7 +65,7 @@ class ValidateXmlCommand extends Command
 
     public function __construct(
         ObjectManagerProvider $objectManagerProvider,
-        string $name = null
+        ?string $name = null
     ) {
         $this->objectManager = $objectManagerProvider->get();
         $this->domDocumentFactory = $this->objectManager->create(DomDocumentFactory::class);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command initialization compatibility by allowing an optional command name to be omitted without type issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->